### PR TITLE
Fix: avoid TypeError when sensor data is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+Payloads/*

--- a/custom_components/copenhagen_trackers/sensor.py
+++ b/custom_components/copenhagen_trackers/sensor.py
@@ -144,7 +144,7 @@ class CellularSignalSensor(CopenhagenTrackersEntity, SensorEntity):
         if value >= -90:
             return "mdi:signal-cellular-1"
         
-        return "mdi:sim-off"
+        return "mdi:signal-cellular-outline"
 
 class GPSSignalSensor(CopenhagenTrackersEntity, SensorEntity):
     """Sensor for GPS signal quality."""

--- a/custom_components/copenhagen_trackers/sensor.py
+++ b/custom_components/copenhagen_trackers/sensor.py
@@ -125,15 +125,21 @@ class CellularSignalSensor(CopenhagenTrackersEntity, SensorEntity):
     @property
     def icon(self) -> str:
         """Return an icon representing the cellular signal strength."""
+        
         value = self.native_value
+        
+        if value is None or value < -100:
+            return "mdi:sim-off"
+        
         if value >= -70:
             return "mdi:signal-cellular-3"
+        
         if value >= -80:
             return "mdi:signal-cellular-2"
+        
         if value >= -90:
             return "mdi:signal-cellular-1"
-        if value >= -100:
-            return "mdi:signal-cellular-outline"
+        
         return "mdi:sim-off"
 
 class GPSSignalSensor(CopenhagenTrackersEntity, SensorEntity):
@@ -182,15 +188,20 @@ class GPSSignalSensor(CopenhagenTrackersEntity, SensorEntity):
     def icon(self) -> str:
         """Return an icon representing the GPS signal quality (bars)."""
         value = self.native_value
+        
+        if value is None or value <= 0:
+            return "mdi:crosshairs-off"
+
         if value >= 4:
             return "mdi:signal-cellular-3"
+        
         if value == 3:
             return "mdi:signal-cellular-2"
+        
         if value == 2:
             return "mdi:signal-cellular-1"
-        if value == 1:
-            return "mdi:signal-cellular-outline"
-        return "mdi:crosshairs-off"
+        
+        return "mdi:signal-cellular-outline"
 
 class ProfileNameSensor(CopenhagenTrackersEntity, SensorEntity):
     """Sensor for device profile name."""

--- a/custom_components/copenhagen_trackers/sensor.py
+++ b/custom_components/copenhagen_trackers/sensor.py
@@ -51,10 +51,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
             ServerSyncAtSensor(coordinator, device[ATTR_ID]),
             LastSeenAtSensor(coordinator, device[ATTR_ID]),
             BatteryPercentageSensor(coordinator, device[ATTR_ID]),
-            CellularSignalSensor(coordinator, device[ATTR_ID]),
             GPSSignalSensor(coordinator, device[ATTR_ID]),
             ProfileNameSensor(coordinator, device[ATTR_ID])
         ))
+        # Only add cellular signal sensor if the API provided cellular info
+        location = device.get("location") or {}
+        device_info = location.get("device_info") or {}
+        if device_info.get("sig_strength") or device_info.get("trans"):
+            entities.append(CellularSignalSensor(coordinator, device[ATTR_ID]))
     
     async_add_entities(entities)
 


### PR DESCRIPTION
Handle None sensor states when rendering icons and only register cellular signal sensor when cellular data is present. This prevents the TypeError reported in issue #4 and avoids exposing empty cellular sensors for devices that don't report cellular metrics in the payload.